### PR TITLE
Change TweenEngine.cs to support custom domain reload settings.

### DIFF
--- a/Runtime/Core/TweenEngine.cs
+++ b/Runtime/Core/TweenEngine.cs
@@ -1,8 +1,16 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Tweens.Core {
   static class TweenEngine {
     readonly internal static List<TweenInstance> instances = new();
+
+    #if UNITY_EDITOR
+    [RuntimeInitializeOnLoadMethod (RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void ClearInstances () {
+      instances.Clear ();
+    }
+    #endif
 
     internal static void Update() {
       for (var i = 0; i < instances.Count; i++) {


### PR DESCRIPTION
Added method to TweenEngine.cs to ensure the static list of TweenInstances is cleared every time play is pressed in the editor.