### PR TITLE
Code called on destroyed tween targets during onStart, onCancel and onFinally

### DIFF
--- a/Runtime/TweenInstance.cs
+++ b/Runtime/TweenInstance.cs
@@ -98,7 +98,7 @@ namespace Tweens {
           return;
         }
       }
-      if (onStart != null) {
+      if (onStart != null && component != null) {
         onStart.Invoke(this);
         onStart = null;
       }
@@ -146,8 +146,10 @@ namespace Tweens {
 
     /// <summary>The cancel method will cancel the Tween. When the Tween is cancelled, the OnCancel and OnFinally delegates will be invoked.</summary>
     public sealed override void Cancel() {
-      onCancel?.Invoke(this);
-      onFinally?.Invoke(this);
+      if (component != null) {
+        onCancel?.Invoke(this);
+        onFinally?.Invoke(this);
+      }
       isDecommissioned = true;
     }
   }


### PR DESCRIPTION
In some occasions onFinally or onStart does get called when a object is already destroyed.
Causing for null reference exceptions within those code blocks. This did not happen in an older version.

Not sure if this approach is the best, it does provide good results in an existing project.
As a performance consideration it could maybe be possible to toggle a boolean during a OnDestroy event.
